### PR TITLE
[Terraform] RDS & Lambda 의 Security Group 설정

### DIFF
--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -1,0 +1,44 @@
+resource "aws_security_group" "rds_sg" {
+  name        = "diary-for-f-rds-sg"
+  description = "Security group for RDS instance"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = []
+    description     = "Allow MySQL access from the application server"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "diary-for-f-rds-sg"
+    Description = "Security group for RDS instance"
+  }
+}
+
+resource "aws_security_group" "lambda_sg" {
+  name        = "diary-for-f-lambda-sg"
+  description = "Security group for Lambda function"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  tags = {
+    Name        = "diary-for-f-lambda-sg"
+    Description = "Security group for Lambda function"
+  }
+}

--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "rds_sg" {
     from_port       = 3306
     to_port         = 3306
     protocol        = "tcp"
-    security_groups = []
+    security_groups = [aws_security_group.lambda_sg.id]
     description     = "Allow MySQL access from the application server"
   }
 


### PR DESCRIPTION
# Changelog
- RDS와 Lambda에 대한 Security Group을 생성하였습니다.
- Lambda가 RDS에 접근할 수 있도록 설정하였습니다.

# Testing
- plan 결과
```
# aws_security_group.lambda_sg will be created
  + resource "aws_security_group" "lambda_sg" {
      + arn                    = (known after apply)
      + description            = "Security group for Lambda function"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = "Allow all outbound traffic"
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "diary-for-f-lambda-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Description" = "Security group for Lambda function"
          + "Name"        = "diary-for-f-lambda-sg"
        }
      + tags_all               = {
          + "Description" = "Security group for Lambda function"
          + "Name"        = "diary-for-f-lambda-sg"
        }
      + vpc_id                 = "vpc-0e513d4d5d6f95daa"
    }

  # aws_security_group.rds_sg will be created
  + resource "aws_security_group" "rds_sg" {
      + arn                    = (known after apply)
      + description            = "Security group for RDS instance"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
                # (1 unchanged attribute hidden)
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = []
              + description      = "Allow MySQL access from the application server"
              + from_port        = 3306
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 3306
            },
        ]
      + name                   = "diary-for-f-rds-sg"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Description" = "Security group for RDS instance"
          + "Name"        = "diary-for-f-rds-sg"
        }
      + tags_all               = {
          + "Description" = "Security group for RDS instance"
          + "Name"        = "diary-for-f-rds-sg"
        }
      + vpc_id                 = "vpc-0e513d4d5d6f95daa"
    }
```

# Ops Impact
N/A

# Version Compatibility
N/A