### PR TITLE
[Terraform] Lambda 함수 모듈 설정

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.0"
+  hashes = [
+    "h1:1niS9AcwxN8CrWemnJS2Xf6vM72+48Xh3xFSS3DFWQo=",
+    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
+    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
+    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
+    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
+    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
+    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
+    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
+    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
+    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
+    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.97.0"
   constraints = "~> 5.0"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,31 @@
+resource "aws_iam_role" "lambda" {
+  name = "diary-for-f-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = {
+    Name        = "diary-for-f-lambda-role"
+    Description = "IAM role for Lambda function"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_vpc" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -1,0 +1,43 @@
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_file = var.source_path
+  output_path = "${path.module}/files/${var.function_name}.zip"
+}
+
+resource "aws_lambda_function" "main" {
+  function_name                  = var.function_name
+  description                    = var.description
+  role                           = var.role_arn
+  handler                        = var.handler
+  runtime                        = var.runtime
+  timeout                        = var.timeout
+  memory_size                    = var.memory_size
+  layers                         = var.layers
+  reserved_concurrent_executions = var.reserved_concurrent_executions
+
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  filename         = data.archive_file.lambda_zip.output_path
+
+  dynamic "environment" {
+    for_each = length(var.environment_variables) > 0 ? [1] : []
+    content {
+      variables = var.environment_variables
+    }
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.vpc_config != null ? [var.vpc_config] : []
+    content {
+      subnet_ids         = var.vpc_config.subnet_ids
+      security_group_ids = var.vpc_config.security_group_ids
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_log_group" "lambda_log_group" {
+  name              = "/aws/lambda/${var.function_name}"
+  retention_in_days = var.log_retention_in_days
+  tags              = var.tags
+}

--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -1,0 +1,19 @@
+output "function_arn" {
+  value       = aws_lambda_function.main.arn
+  description = "The ARN of the Lambda function."
+}
+
+output "function_name" {
+  value       = aws_lambda_function.main.function_name
+  description = "The name of the Lambda function."
+}
+
+output "invoke_arn" {
+  value       = aws_lambda_function.main.invoke_arn
+  description = "The ARN that you can use to invoke the Lambda function."
+}
+
+output "log_group_name" {
+  value       = aws_cloudwatch_log_group.lambda_log_group.name
+  description = "The name of the CloudWatch log group for the Lambda function."
+}

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -1,0 +1,78 @@
+variable "function_name" {
+  type        = string
+  description = "The name of the Lambda function."
+}
+
+variable "description" {
+  type        = string
+  description = "The description of the Lambda function."
+}
+
+variable "handler" {
+  type        = string
+  description = "The function entrypoint in your code."
+}
+
+variable "runtime" {
+  type        = string
+  description = "The runtime environment for the Lambda function that you are uploading."
+}
+
+variable "timeout" {
+  type        = number
+  description = "The amount of time that Lambda allows a function to run before stopping it. (seconds)"
+}
+
+variable "memory_size" {
+  type        = number
+  description = "The amount of memory available to the function at runtime. (MB)"
+}
+
+variable "source_path" {
+  type        = string
+  description = "The path to the source code of the Lambda function."
+}
+
+variable "environment_variables" {
+  type        = map(string)
+  description = "Environment variables that are accessible from function code during execution."
+  default     = {}
+}
+
+variable "role_arn" {
+  type        = string
+  description = "The ARN of the IAM role that Lambda assumes when it executes your function."
+}
+
+variable "vpc_config" {
+  type = object({
+    subnet_ids         = list(string)
+    security_group_ids = list(string)
+  })
+  description = "VPC configuration for the Lambda function."
+  default     = null
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to assign to the Lambda function."
+  default     = {}
+}
+
+variable "log_retention_in_days" {
+  type        = number
+  description = "The number of days to retain logs for."
+  default     = 14
+}
+
+variable "layers" {
+  type        = list(string)
+  description = "A list of Lambda Layer ARNs to attach to the function."
+  default     = []
+}
+
+variable "reserved_concurrent_executions" {
+  type        = number
+  description = "The number of concurrent executions reserved for the function."
+  default     = -1
+}


### PR DESCRIPTION
# Changelog
- Lambda함수를 Terraform으로 간편하게 설정할 수 있도록 Terraform module을 추가하였습니다.
- Lambda함수 전용 IAM Role을 추가하였습니다.
- 사용법은 다음과 같고, 예시는 아래에 첨부하였습니다.
  1. `/terraform/src` 디렉토리에 코드를 작성합니다.
  2. `lambda` 모듈을 사용하고 작성한 코드를 `source_path`에 전달합니다.

```
# src/test_lambda.py

import boto3


def lambda_handler(event, context):
    """
    AWS Lambda function handler that returns a greeting message.
    
    Args:
        event (dict): The event data passed to the Lambda function.
        context (LambdaContext): The runtime information of the Lambda function.

    Returns:
        dict: A response containing a greeting message.
    """
    return {'statusCode': 200, 'body': 'Hello from Lambda!'}
```
```
# test_lambda.tf

module "test_lambda" {
  source = "./modules/lambda"

  function_name         = "test_lambda"
  description           = "Test Lambda function"
  source_path           = "src/test_lambda.py"
  role_arn              = aws_iam_role.lambda.arn
  handler               = "test_lambda.lambda_handler"
  runtime               = "python3.13"
  timeout               = 30
  memory_size           = 128
  layers                = []
  environment_variables = {}
  vpc_config            = null
  tags                  = { Name = "test_lambda" }
  log_retention_in_days = 7
}
```

# Testing
위 예시로 Lambda함수를 생성한 후 Test한 결과
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/eefdddf6-7f63-40bf-961c-8226618c4984" />

# Ops Impact
N/A

# Version Compatibility
N/A