### PR TITLE
[Terraform] 데이터베이스 Aurora-MySQL 로 변경

### DIFF
--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -1,6 +1,6 @@
 data "archive_file" "lambda_zip" {
   type        = "zip"
-  source_file = var.source_path
+  source_dir  = var.source_path
   output_path = "${path.module}/files/${var.function_name}.zip"
 }
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,39 +1,48 @@
-data "aws_secretsmanager_secret" "rds_credentials" {
-  name = "diary-for-f/db-credentials"
+data "aws_secretsmanager_secret" "aurora_credentials" {
+  name = "diary-for-f/aurora-credentials"
 }
 
-data "aws_secretsmanager_secret_version" "rds_credentials" {
-  secret_id = data.aws_secretsmanager_secret.rds_credentials.id
+data "aws_secretsmanager_secret_version" "aurora_credentials" {
+  secret_id = data.aws_secretsmanager_secret.aurora_credentials.id
 }
 
 locals {
-  db_credentials = jsondecode(data.aws_secretsmanager_secret_version.rds_credentials.secret_string)
+  db_credentials = jsondecode(data.aws_secretsmanager_secret_version.aurora_credentials.secret_string)
 }
 
-resource "aws_db_instance" "mysql" {
-  identifier           = local.db_credentials.dbInstanceIdentifier
-  allocated_storage    = 5 # 5GB
-  storage_type         = "gp2"
-  engine               = local.db_credentials.engine
-  engine_version       = "8.0"
-  instance_class       = "db.t3.micro"
-  parameter_group_name = "default.mysql8.0"
-  skip_final_snapshot  = true
-  publicly_accessible  = false
-  db_name              = local.db_credentials.dbname
-  username             = local.db_credentials.username
-  password             = local.db_credentials.password
-
-  db_subnet_group_name   = aws_db_subnet_group.mysql_subnet_group.name
-  vpc_security_group_ids = [aws_security_group.rds_sg.id]
-}
-
-resource "aws_db_subnet_group" "mysql_subnet_group" {
-  name       = "diary-for-f-mysql-subnet-group"
+resource "aws_db_subnet_group" "aurora_subnet_group" {
+  name       = "diary-for-f-aurora-subnet-group"
   subnet_ids = [aws_subnet.private_a.id, aws_subnet.private_b.id]
 
   tags = {
-    Name        = "diary-for-f-mysql-subnet-group"
-    Description = "Subnet group for RDS MySQL instance"
+    Name        = "diary-for-f-aurora-subnet-group"
+    Description = "Subnet group for Aurora RDS"
   }
+}
+
+resource "aws_rds_cluster" "aurora" {
+  cluster_identifier     = local.db_credentials.dbClusterIdentifier
+  engine                 = "aurora-mysql"
+  engine_version         = "8.0.mysql_aurora.3.08.0"
+  database_name          = "diary_for_f"
+  master_username        = local.db_credentials.username
+  master_password        = local.db_credentials.password
+  db_subnet_group_name   = aws_db_subnet_group.aurora_subnet_group.name
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  skip_final_snapshot    = true
+
+  serverlessv2_scaling_configuration {
+    max_capacity             = 1.0
+    min_capacity             = 0.0
+    seconds_until_auto_pause = 3600
+  }
+}
+
+resource "aws_rds_cluster_instance" "aurora_instances" {
+  identifier          = "diary-for-f-aurora-instance"
+  instance_class      = "db.serverless" # Use serverless instance class
+  cluster_identifier  = aws_rds_cluster.aurora.id
+  engine              = aws_rds_cluster.aurora.engine
+  engine_version      = aws_rds_cluster.aurora.engine_version
+  publicly_accessible = false
 }


### PR DESCRIPTION
# Changelog
- DB를 `RDS-mySQL`에서 `RDS-Aurora-mySQL`로 변경하였습니다.
  - Aurora는 기존 MySQL보다 성능이 빠르고 유연하게 확장할 수 있습니다. 또한 Aurora는 Serverless로 설정 가능해 실제 작업이 발생할때만 요금이 부과되므로 비용효율적이여서 변경하였습니다.
- Aurora MySQL 관련 Credentials를 포함한 Secret을 생성하고 Terraform에서 사용하였습니다.

# Testing
<img width="501" alt="image" src="https://github.com/user-attachments/assets/d4cc99b0-42dc-4799-8065-5f5de2b40c6a" />

# Ops Impact
N/A

# Version Compatibility
N/A