### PR TITLE
[Terraform] 로컬에서 데이터베이스에 접근하기 위한 SSH 터널링 구성

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,25 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/archive" {
-  version = "2.7.0"
-  hashes = [
-    "h1:1niS9AcwxN8CrWemnJS2Xf6vM72+48Xh3xFSS3DFWQo=",
-    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
-    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
-    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
-    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
-    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
-    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
-    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
-    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
-    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
-    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.97.0"
   constraints = "~> 5.0"

--- a/terraform/bastion.tf
+++ b/terraform/bastion.tf
@@ -1,0 +1,30 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "bastion" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = "t2.micro"
+  subnet_id                   = aws_subnet.public_a.id
+  vpc_security_group_ids      = [aws_security_group.bastion_sg.id]
+  associate_public_ip_address = true
+  key_name                    = data.aws_key_pair.ssh_key.key_name
+
+  tags = {
+    Name        = "diary-for-f-bastion"
+    Description = "Bastion host for diary-for-f"
+  }
+}
+
+data "aws_key_pair" "ssh_key" {
+  key_name = "ssh_key"
+}

--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -11,6 +11,14 @@ resource "aws_security_group" "rds_sg" {
     description     = "Allow MySQL access from the application server"
   }
 
+  ingress {
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion_sg.id]
+    description     = "Allow MySQL access from the bastion host"
+  }
+
   egress {
     from_port   = 0
     to_port     = 0
@@ -40,5 +48,32 @@ resource "aws_security_group" "lambda_sg" {
   tags = {
     Name        = "diary-for-f-lambda-sg"
     Description = "Security group for Lambda function"
+  }
+}
+
+resource "aws_security_group" "bastion_sg" {
+  name        = "diary-for-f-bastion-sg"
+  description = "Security group for bastion host"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow SSH access from anywhere"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  tags = {
+    Name        = "diary-for-f-bastion-sg"
+    Description = "Security group for bastion host"
   }
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -30,3 +30,60 @@ resource "aws_subnet" "private_b" {
     Description = "Private subnet B for diary-for-f"
   }
 }
+
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.10.0/24"
+  availability_zone       = "ap-northeast-2a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "diary-for-f-public-a"
+    Description = "Public subnet A for diary-for-f"
+  }
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.12.0/24"
+  availability_zone       = "ap-northeast-2c"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "diary-for-f-public-b"
+    Description = "Public subnet B for diary-for-f"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name        = "diary-for-f-internet-gateway"
+    Description = "Internet gateway for diary-for-f"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name        = "diary-for-f-public-route-table"
+    Description = "Public route table for diary-for-f"
+  }
+}
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_b" {
+  subnet_id      = aws_subnet.public_b.id
+  route_table_id = aws_route_table.public.id
+}


### PR DESCRIPTION
# Changelog
- 개발자나 관리자가 데이터베이스에 접근하기 용이하도록 SSH 터널링에 필요한 요소들을 구성하였습니다.
  - Bastion EC2 인스턴스를 생성하고 RDS의 Security Group에 추가하여 접근가능하도록 하였습니다.
  - 로컬에서 Bastion EC2에 SSH연결을 할 때는 RSA Key Pair를 통해 인증하도록 설정하였습니다. (PEM 파일은 비밀~)

# Testing
로컬에서 Datagrip을 사용해 연결 가능한 것을 확인하였습니다.

# Ops Impact
N/A

# Version Compatibility
N/A