### PR TITLE
[Terraform] VPC Endpoint 설정

### DIFF
--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -77,3 +77,23 @@ resource "aws_security_group" "bastion_sg" {
     Description = "Security group for bastion host"
   }
 }
+
+resource "aws_security_group" "vpce" {
+  name        = "vpce-sg"
+  description = "Allow HTTPS traffic for VPC Endpoint"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lambda_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -87,3 +87,49 @@ resource "aws_route_table_association" "public_b" {
   subnet_id      = aws_subnet.public_b.id
   route_table_id = aws_route_table.public.id
 }
+
+resource "aws_vpc_endpoint" "bedrock" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.ap-northeast-2.bedrock"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = [
+    aws_subnet.public_a.id,
+    aws_subnet.public_b.id
+  ]
+
+  security_group_ids = [
+    aws_security_group.vpce.id,
+    aws_security_group.lambda_sg.id
+  ]
+
+  private_dns_enabled = true
+
+  tags = {
+    Name        = "diary-for-f-bedrock-vpc-endpoint"
+    Description = "VPC endpoint for Bedrock service"
+  }
+}
+
+resource "aws_vpc_endpoint" "bedrock_runtime" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.ap-northeast-2.bedrock-runtime"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = [
+    aws_subnet.public_a.id,
+    aws_subnet.public_b.id
+  ]
+
+  security_group_ids = [
+    aws_security_group.vpce.id,
+    aws_security_group.lambda_sg.id
+  ]
+
+  private_dns_enabled = true
+
+  tags = {
+    Name        = "diary-for-f-bedrock-bedrock-vpc-endpoint"
+    Description = "VPC endpoint for Bedrock Bedrock service"
+  }
+}


### PR DESCRIPTION
# Changelog
- Lambda함수에서 Bedrock에 접근하기 위해 Bedrock의 VPC Endpoint를 설정하였습니다. (`bedrock`, `bedrock-runtime`)
- VPC Endpoint의 Security Group을 설정하고 Lambda의 HTTPS Ingress를 허용하였습니다.

# Testing
- `create_diary` 에서 Bedrock Runtime 접근 성공

# Ops Impact
N/A

# Version Compatibility
N/A