### PR TITLE
[iOS] 일기 작성 화면 구현

### DIFF
--- a/Feelim-ios/Feelim-ios/Models/DiaryEntry.swift
+++ b/Feelim-ios/Feelim-ios/Models/DiaryEntry.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct DiaryEntry: Identifiable {
-    let id = UUID()
+    var id = UUID()
     let date: String               // ex. "2025.05.01"
     let timestamp: String          // ex. "2025.05.01 18:20"
     let emotionImageName: String   // ex. "sad", "happy"…
@@ -17,4 +17,39 @@ struct DiaryEntry: Identifiable {
     // AI 답장용 필드
     let aiReply: String
     let aiImageName: String        // "robot"
+    
+    // 기본 생성자
+    init(
+        id: UUID = UUID(),
+        date: String,
+        timestamp: String,
+        emotionImageName: String,
+        content: String,
+        aiReply: String,
+        aiImageName: String
+    ) {
+        self.id = id
+        self.date = date
+        self.timestamp = timestamp
+        self.emotionImageName = emotionImageName
+        self.content = content
+        self.aiReply = aiReply
+        self.aiImageName = aiImageName
+    }
+    
+    // 새로운 일기 생성 시 사용
+    init(
+        date: String,
+        timestamp: String,
+        emotionImageName: String,
+        content: String
+    ) {
+        self.id = UUID()
+        self.date = date
+        self.timestamp = timestamp
+        self.emotionImageName = emotionImageName
+        self.content = content
+        self.aiReply = ""         // 아직 AI 답장은 비어 있음
+        self.aiImageName = ""     // 나중에 채워질 수 있도록 빈 문자열
+    }
 }

--- a/Feelim-ios/Feelim-ios/Views/DiaryWriteView.swift
+++ b/Feelim-ios/Feelim-ios/Views/DiaryWriteView.swift
@@ -1,0 +1,158 @@
+//
+//  DiaryWriteView.swift
+//  Feelim-ios
+//
+//  Created by 김동인 on 6/3/25.
+//
+
+import SwiftUI
+
+// 새 일기를 작성하는 모달 뷰
+struct DiaryWriteView: View {
+    var onSave: (DiaryEntry) -> Void
+    var onCancel: () -> Void
+
+    private let now = Date()
+    private let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy.MM.dd"
+        return f
+    }()
+    private let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy.MM.dd HH:mm"
+        return f
+    }()
+
+    @State private var content: String = ""
+    @State private var selectedEmotion: String = "happy"
+    private let maxCharacters = 150
+    private let emotions = ["sad", "neutral", "happy", "angry", "anxious", "surprised"]
+
+    var body: some View {
+        ZStack {
+            // 흰색 프레임
+            Rectangle()
+                .fill(Color.white)
+                .frame(width: 394, height: 568.60)
+                .shadow(color: Color.black.opacity(0.10), radius: 16.52)
+            
+            // 검은색 입력 영역
+            Rectangle()
+                .fill(Color.black)
+                .frame(width: 349.89, height: 456.20)
+                .offset(x: -1, y: -23.65)
+            
+            // TextEditor + Placeholder
+            ZStack {
+                if content.isEmpty {
+                    Text("오늘 하루를\n\n한 장의 필름에 담는다면\n\n어떤 모습일까요?\n\n마음에 스친 오늘의 감정들을\n\n   조용히 필름 위에 담아보세요.\n\n\n")
+                        .font(.custom("SF Pro Display", size: 18).weight(.medium))
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(Color.white.opacity(0.5))
+                        .padding(.horizontal, 16)
+                }
+                TextEditor(text: $content)
+                    .font(.custom("SF Pro Display", size: 20).weight(.medium))
+                    .lineSpacing(29)
+                    .padding(.horizontal, 8)
+                    .foregroundColor(Color.white)
+                    .scrollContentBackground(.hidden) // 이걸 넣어야 입력 창 배경이 사라짐!!
+                    .frame(width: 349.89, height: 400)
+                    .offset(x: -1, y: -23.65)
+            }
+            
+            // 글자 수 카운트
+            Text("\(content.count)/\(maxCharacters)")
+                .font(.custom("Roboto", size: 15))
+                .offset(x: 129.50, y: 181.80)
+                .foregroundColor(Color.white)
+
+            // 감정 선택 스크롤
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 23) {
+                    ForEach(emotions, id: \.self) { emo in
+                        Image(emo)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 50, height: 70)
+                            .clipShape(Circle())
+                            .overlay(
+                                Circle()
+                                    .stroke(selectedEmotion == emo ? Color.black : Color.clear, lineWidth: 2)
+                            )
+                            .onTapGesture {
+                                selectedEmotion = emo
+                            }
+                    }
+                }
+                .offset(x: -30)
+                .padding(.leading, 16)
+            }
+            .frame(width: 370, height: 70)
+            .offset(y: 245)
+            
+            // 취소, 저장 버튼
+            HStack(spacing: 20) {
+                Button(action: {
+                    onCancel()
+                }) {
+                    Text("취소")
+                        .font(.custom("SF Pro Display", size: 16).weight(.bold))
+                        .foregroundColor(.white)
+                        .frame(width: 150, height: 50)
+                        .background(Color.gray)
+                        .clipShape(Capsule())
+                }
+                
+                Button(action: {
+                    let emotionIndex = emotions.firstIndex(of: selectedEmotion) ?? 2
+                    let newEntry = DiaryEntry(
+                        date: dateFormatter.string(from: now),
+                        timestamp: timeFormatter.string(from: now),
+                        emotionImageName: emotions[emotionIndex],
+                        content: content.trimmingCharacters(in: .whitespacesAndNewlines),
+                        aiReply: "",
+                        aiImageName: "robot"
+                    )
+                    onSave(newEntry)
+                }) {
+                    Text("저장")
+                        .font(.custom("SF Pro Display", size: 16).weight(.bold))
+                        .foregroundColor(.black)
+                        .frame(width: 150, height: 50)
+                        .background(Color.white)
+                        .clipShape(Capsule())
+                }
+            }
+            .padding(.bottom, 30)
+            .offset(x: 0, y: 350)
+        } // ZStack 끝
+        .padding(.top, 20)
+        .background(Color.white)
+        .frame(width: 394, height: 568.60)
+        .onChange(of: content) {
+            if content.count > maxCharacters {
+                content = String(content.prefix(maxCharacters))
+            }
+        }
+    }
+}
+
+
+struct DiaryWriteView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            Color(red: 0.15, green: 0.15, blue: 0.15).ignoresSafeArea()
+
+            DiaryWriteView(
+                onSave: { entry in
+                    print("저장된 일기:", entry)
+                },
+                onCancel: {
+                    print("취소됨")
+                }
+            )
+        }
+    }
+}

--- a/Feelim-ios/Feelim-ios/Views/HomeView.swift
+++ b/Feelim-ios/Feelim-ios/Views/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     // 여러 줄의 감정 일기들 샘플
-    let photoLines: [[DiaryEntry]] = [
+    @State private var photoLines: [[DiaryEntry]] = [
         [
             DiaryEntry(
                 date: "2025.05.01",
@@ -233,7 +233,11 @@ struct HomeView: View {
     ]
 
     
+    // 특정 일기 선택 여부
     @State private var selectedEntry : DiaryEntry?
+    
+    // 새 일기 작성 화면 표시 여부
+    @State private var isPresentingWriteView = false
 
     var body: some View {
         
@@ -254,10 +258,12 @@ struct HomeView: View {
                     Spacer()
                 }
 
+                // 일기 목록
                 ScrollView(.vertical, showsIndicators: false) {
                     VStack(spacing: 64) {
                         ForEach(photoLines.indices, id: \.self) { index in
                             PhotoLineView(entries: photoLines[index]) { entry in
+                                // 클릭된 일기 선택
                                 selectedEntry = entry
                             }
                         }
@@ -272,7 +278,7 @@ struct HomeView: View {
             VStack {
                 Spacer()
                 Button(action: {
-                    // TODO : 새 일기 추가 액션
+                    isPresentingWriteView = true
                 }) {
                     ZStack {
                         Circle()
@@ -284,6 +290,31 @@ struct HomeView: View {
                     }
                 }
                 .padding(.bottom, 30)
+            }
+            
+            // 일기 작성 모달
+            if isPresentingWriteView {
+                Color.black.opacity(0.6)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        isPresentingWriteView = false
+                    }
+                DiaryWriteView(
+                    onSave: { newEntry in
+                        if photoLines.isEmpty {
+                            photoLines = [[newEntry]]
+                        } else {
+                            photoLines[0].insert(newEntry, at: 0)
+                        }
+                        isPresentingWriteView = false
+                    }
+                    , onCancel: {
+                        isPresentingWriteView = false
+                    }
+                )
+                .frame(width: 394, height: 568.60)
+                .shadow(color: Color.black.opacity(0.1), radius: 16, x: 0, y: 0)
+                .zIndex(1)
             }
             
             // 특정 일기 조회 모달


### PR DESCRIPTION
# Changelog
- 일기 작성 화면 구현

# Testing
- 수동 테스트 진행
    - 홈 화면에서 작성 버튼 클릭 → 일기 작성 모달 정상 출력 확인
    - 감정 이모지 스크롤 정상 동작 확인
    - 플레이스홀더 문구 정상 출력 확인
    - 최대 글자수 150자 초과 시 자동 제한 정상 작동 확인
    - 저장 버튼 클릭 시 새로운 DiaryEntry 정상 생성 및 저장 로직 호출 확인
    - 취소 버튼 클릭 시 모달 정상 닫힘 확인

# Ops Impact
- N/A

# Version Compatibility
- N/A
