### PR TITLE
[Terraform] API Gateway 및 Endpoint 구현

### DIFF
--- a/terraform/api_endpoints.tf
+++ b/terraform/api_endpoints.tf
@@ -1,0 +1,81 @@
+resource "aws_api_gateway_rest_api" "diary_api" {
+  name        = "diary-for-f-api"
+  description = "API Gateway for Diary for F application"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+module "get_diary_list_endpoint" {
+  source                 = "./modules/api_endpoint/"
+  rest_api_id            = aws_api_gateway_rest_api.diary_api.id
+  rest_api_execution_arn = aws_api_gateway_rest_api.diary_api.execution_arn
+  parent_resource_id     = aws_api_gateway_rest_api.diary_api.root_resource_id
+  path_part              = "diaries"
+  http_method            = "GET"
+  uri                    = module.get_diary_list.invoke_arn
+  lambda_function_name   = module.get_diary_list.function_name
+}
+
+module "create_diary_endpoint" {
+  source                 = "./modules/api_endpoint/"
+  rest_api_id            = aws_api_gateway_rest_api.diary_api.id
+  rest_api_execution_arn = aws_api_gateway_rest_api.diary_api.execution_arn
+  parent_resource_id     = aws_api_gateway_rest_api.diary_api.root_resource_id
+  path_part              = "diary"
+  http_method            = "POST"
+  uri                    = module.create_diary.invoke_arn
+  lambda_function_name   = module.create_diary.function_name
+}
+
+module "get_diary_endpoint" {
+  source                 = "./modules/api_endpoint/"
+  rest_api_id            = aws_api_gateway_rest_api.diary_api.id
+  rest_api_execution_arn = aws_api_gateway_rest_api.diary_api.execution_arn
+  parent_resource_id     = aws_api_gateway_rest_api.diary_api.root_resource_id
+  path_part              = "diary"
+  http_method            = "GET"
+  uri                    = module.get_diary.invoke_arn
+  lambda_function_name   = module.get_diary.function_name
+}
+
+module "get_ai_feedback_endpoint" {
+  source                 = "./modules/api_endpoint/"
+  rest_api_id            = aws_api_gateway_rest_api.diary_api.id
+  rest_api_execution_arn = aws_api_gateway_rest_api.diary_api.execution_arn
+  parent_resource_id     = aws_api_gateway_rest_api.diary_api.root_resource_id
+  path_part              = "ai-feedback"
+  http_method            = "GET"
+  uri                    = module.get_ai_feedback.invoke_arn
+  lambda_function_name   = module.get_ai_feedback.function_name
+}
+
+resource "aws_api_gateway_deployment" "diary_api" {
+  rest_api_id = aws_api_gateway_rest_api.diary_api.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [
+    module.get_diary_list_endpoint,
+    module.create_diary_endpoint,
+    module.get_diary_endpoint,
+    module.get_ai_feedback_endpoint,
+    module.test_lambda_endpoint,
+  ]
+}
+
+resource "aws_api_gateway_stage" "diary_api_stage" {
+  stage_name    = "prod"
+  rest_api_id   = aws_api_gateway_rest_api.diary_api.id
+  deployment_id = aws_api_gateway_deployment.diary_api.id
+
+  description = "Production stage for Diary for F API"
+
+  tags = {
+    Name        = "diary-for-f-api-stage"
+    Description = "Production stage for Diary for F API"
+  }
+}

--- a/terraform/modules/api_endpoint/main.tf
+++ b/terraform/modules/api_endpoint/main.tf
@@ -1,0 +1,30 @@
+resource "aws_api_gateway_resource" "this" {
+  rest_api_id = var.rest_api_id
+  parent_id   = var.parent_resource_id
+  path_part   = var.path_part
+}
+
+resource "aws_api_gateway_method" "this" {
+  rest_api_id   = var.rest_api_id
+  resource_id   = aws_api_gateway_resource.this.id
+  http_method   = var.http_method
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "this" {
+  rest_api_id = var.rest_api_id
+  resource_id = aws_api_gateway_resource.this.id
+  http_method = aws_api_gateway_method.this.http_method
+
+  integration_http_method = "POST" # NOTE: Lambda only supports POST for AWS_PROXY
+  type                    = "AWS_PROXY"
+  uri                     = var.uri
+}
+
+resource "aws_lambda_permission" "apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${var.rest_api_execution_arn}/*/*"
+}

--- a/terraform/modules/api_endpoint/variables.tf
+++ b/terraform/modules/api_endpoint/variables.tf
@@ -1,0 +1,33 @@
+variable "rest_api_id" {
+  type        = string
+  description = "The ID of the API Gateway REST API to which the Lambda function will be integrated."
+}
+
+variable "parent_resource_id" {
+  type        = string
+  description = "The ID of the parent resource in the API Gateway where the Lambda function will be integrated."
+}
+
+variable "rest_api_execution_arn" {
+  type        = string
+  description = "The execution ARN of the API Gateway REST API."
+}
+variable "path_part" {
+  type        = string
+  description = "The path part for the API Gateway resource where the Lambda function will be integrated."
+}
+
+variable "http_method" {
+  type        = string
+  description = "The HTTP method for the API Gateway method that will invoke the Lambda function. (e.g., GET, POST)"
+}
+
+variable "uri" {
+  type        = string
+  description = "The URI for the Lambda function integration in the API Gateway."
+}
+
+variable "lambda_function_name" {
+  type        = string
+  description = "The name of the Lambda function to be invoked by the API Gateway."
+}


### PR DESCRIPTION
# Changelog
- #23 에서 구현한 API들을 사용하기 위해 API Gateway를 생성하였습니다.
- `api_endpoint` 모듈을 생성하여 람다 함수를 API Gateway와 통합하였습니다.
- 각 람다 함수를 다음과 같이 매핑하였습니다.
  - `get_diary_list`: `GET {BASE_URL}/diaries?limit={limit}&page={page}`
  - `create_diary`: `POST {BASE_URL}/diary`
  - `get_diary`: `GET {BASE_URL}/diary?id={id}`
  - `get_ai_feedback`: `GET {BASE_URL}/ai-feedback?id={id}`

# Testing
- API Gateway 생성 확인
<img width="303" alt="image" src="https://github.com/user-attachments/assets/a2f40024-44ed-462f-9964-3c12269e49a1" />

- Postman으로 API 요청 확인

# Ops Impact
N/A

# Version Compatibility
N/A